### PR TITLE
keeping track of excluded trials 

### DIFF
--- a/helper/preprocessing_helper.R
+++ b/helper/preprocessing_helper.R
@@ -154,6 +154,7 @@ exclude_by <- function(d, col, setting = "all", action = "exclude",
   
   if (!quiet) print(paste("filtering by", quo_name(col)))
   
+  
   percent_trial <- d %>%
     ungroup %>%
     summarise(trial_sum = sum(!! col, na.rm=TRUE),
@@ -170,9 +171,12 @@ exclude_by <- function(d, col, setting = "all", action = "exclude",
               all_mean = mean(all, na.rm=TRUE))
   
   if (!quiet) {
+    
+    
     print(paste("This variable excludes", percent_trial$trial_sum, "trials, which is ", 
                 round(percent_trial$trial_mean*100, digits = 1), "% of all trials."))
     
+
     if (setting == "any") {
       print(paste(percent_sub$any_sum, " subjects,", 
                   round(percent_sub$any_mean*100, digits = 1),
@@ -184,6 +188,15 @@ exclude_by <- function(d, col, setting = "all", action = "exclude",
                   ifelse(action == "include", "true:", "false:"), 
                   action))
     }
+    
+    # give table showing excluded samples
+    print('Excluded: ')
+    # print short table of excluded data
+    d %>% 
+      filter( !! col) %>%
+      kable(digits=2) %>%
+      print(. + '\n')
+
   }
   
   if (action=="NA out") {

--- a/pilot_data_analysis.Rmd
+++ b/pilot_data_analysis.Rmd
@@ -32,7 +32,7 @@ labs <- dir(here::here("pilot_data"))
 
 for (lab in labs) {
   print(lab)
-  source(here::here("pilot_data", lab, "import.R"))
+  source(here::here("pilot_data", lab, "import_scripts", "import.R"))
 }
 
 ```

--- a/pilot_data_analysis.Rmd
+++ b/pilot_data_analysis.Rmd
@@ -69,8 +69,8 @@ d <- labs %>%
 # Exclusions
 
 ```{r}
-# filter subjects marked error
-d <- filter(d, error == F)
+# bookkeeping of excluded trials
+d <- exclude_by(d, quo(error), quiet=FALSE)
 
 # print trials under 35s
 group_by(d, lab, trial_id, subid) %>%

--- a/pilot_data_analysis.Rmd
+++ b/pilot_data_analysis.Rmd
@@ -40,7 +40,6 @@ for (lab in labs) {
 
 # File reading
 
-
 ```{r}
 labs <- dir(here::here("pilot_data"))
 
@@ -69,19 +68,18 @@ d <- labs %>%
 # Exclusions
 
 ```{r}
-# bookkeeping of excluded trials
-d <- exclude_by(d, quo(error), quiet=FALSE)
+# exclude subject marked with any error & less than 8 trials
+d <- d %>% 
+  group_by(lab, subid) %>%
+  summarise(error_subj = any(error), num_trials = length(unique(trial_id))) %>%
+      exclude_by(quo(error_subj), quiet=FALSE) %>%
+      exclude_by(quo(num_trials < 8), quiet=FALSE) 
 
-# print trials under 35s
-group_by(d, lab, trial_id, subid) %>%
-  summarise(time_range = (max(t) - min(t))/1000)  %>%
-  filter(time_range <= 35) %>%
-  kable(digits=2)
-
-# filter trials under 35s (which are not complete trials)
-d <- group_by(d, lab, trial_id, subid) %>%
-  mutate(time_range = (max(t) - min(t))/1000) %>%
-  filter(time_range > 35)
+# remove trials under 35s (which are not complete trials)
+d <- d %>% 
+  group_by(lab, trial_id, subid) %>%
+  summarise(time_range = (max(t) - min(t))/1000) %>%
+          exclude_by(quo(time_range <= 35), quiet=FALSE)
 
 # print trial time ranges by lab
 ungroup(d) %>%
@@ -90,18 +88,7 @@ ungroup(d) %>%
             longest_trial=max(time_range)) %>%
   kable(digits=2)
 
-# print subjects who did not complete all trials and then filter
-d %>%
-  group_by(lab, subid) %>%
-  summarise(trials_completed = length(unique(trial_id))) %>%
-  filter(trials_completed < 8) %>%
-  kable(digits=2)
-
-d <- ungroup(d) %>%
-  group_by(lab, subid) %>%
-  filter(length(unique(trial_id)) >= 8)
 ```
-
 
 # Analysis
 


### PR DESCRIPTION
made **Exclusions** section in pilot_data_analysis.R more compact and used the function _'exclude_by'_ to keep track of excluded entries. Also, instead of having code to print out excluded trials in pilot_data_analysis, _'exclude_by'_ now prints a table of excluded entries if its argument 'quiet' is set to TRUE 